### PR TITLE
Handle focus and programmatic clicks in shadow DOM

### DIFF
--- a/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
+++ b/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
@@ -38,7 +38,7 @@ class WebConfiguration is ApplicationConfiguration
     presses the Tab key, the window will lose focus. If it is true, the window
     will keep the focus even if the user presses Tab.
     */
-    public boolean keepTabFocus = false
+    public boolean keepTabFocus = true
 
     /*
     The maximum number of seconds allowed between each mouse click before the

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/InputMonitor.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/InputMonitor.js
@@ -2,7 +2,7 @@ function plugins_quorum_Libraries_Game_InputMonitor_()
 {
     this.IsKeyPressed$quorum_integer = function(keyCode)
     {
-        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas() === document.activeElement)
+        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             return plugins_quorum_Libraries_Game_WebInput_.pressedKeys[keyCode] === true;
 
         return false;
@@ -10,7 +10,7 @@ function plugins_quorum_Libraries_Game_InputMonitor_()
     
     this.IsMouseButtonPressed$quorum_integer = function(buttonCode)
     {
-        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas() === document.activeElement)
+        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
         {
             var buttons = plugins_quorum_Libraries_Game_WebInput_.mouseInfo.buttons;
             switch (buttonCode)
@@ -55,7 +55,7 @@ function plugins_quorum_Libraries_Game_InputMonitor_()
     
     this.IsClicked = function()
     {
-        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas() === document.activeElement)
+        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             return plugins_quorum_Libraries_Game_WebInput_.mouseInfo.buttons > 0;
     };
     

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
@@ -34,6 +34,18 @@ function plugins_quorum_Libraries_Game_WebDisplay_()
         return canvas;
     };
     
+    this.IsCanvasFocused = function()
+    {
+        let element = document.activeElement;
+        while (element) {
+            if (element === canvas) {
+                return true;
+            }
+            element = element.parentElement;
+        }
+        return false;
+    };
+    
     this.SetDisplayMode$quorum_integer$quorum_integer$quorum_boolean = function(width, height, fullscreen)
     {
         // Currently resizes canvas but does not support fullscreen.

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
@@ -16,7 +16,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.KeyDown = function(event)
         {
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas() === document.activeElement)
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumKeyEvent(event, true);
                 if (!plugins_quorum_Libraries_Game_WebInput_.pressedKeys[quorumEvent.Get_Libraries_Interface_Events_KeyboardEvent__keyCode_()])
@@ -30,7 +30,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.KeyUp = function(event)
         {
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas() === document.activeElement)
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumKeyEvent(event, false);
                 if (plugins_quorum_Libraries_Game_WebInput_.pressedKeys[quorumEvent.Get_Libraries_Interface_Events_KeyboardEvent__keyCode_()])
@@ -71,8 +71,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.MouseUp = function(event)
         {
-            var canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
-            if (canvas === document.activeElement)
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 4);
                 plugins_quorum_Libraries_Game_WebInput_.mouseEvents.push(quorumEvent);
@@ -81,8 +80,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.MouseMove = function(event)
         {
-            var canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
-            if (canvas === document.activeElement)
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 // If no mouse buttons pressed, send code for MOVED_MOUSE. Otherwise, send DRAGGED_MOUSE.
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, event.buttons > 0 ? 3 : 2);
@@ -92,8 +90,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.MouseScroll = function(event)
         {
-            var canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
-            if (canvas === document.activeElement)
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 5);
                 plugins_quorum_Libraries_Game_WebInput_.mouseEvents.push(quorumEvent);
@@ -102,8 +99,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.ContextMenu = function(event)
         {
-            var canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
-            if (canvas === document.activeElement)
+            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 if (plugins_quorum_Libraries_Game_WebInput_.disableContextMenu)
                     event.preventDefault();

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
@@ -32,6 +32,15 @@ function plugins_quorum_Libraries_Game_WebInput_()
         {
             if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
+                if (event.code === "Escape" && plugins_quorum_Libraries_Game_WebInput_.keepTabFocus())
+                {
+                    // If we trap focus inside the canvas, give the user a way
+                    // to get out. Do this in the key up handler to ensure
+                    // Quorum gets the key up event for Escape, even though
+                    // the canvas is about to lose focus.
+                    document.activeElement.blur();
+                }
+
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumKeyEvent(event, false);
                 if (plugins_quorum_Libraries_Game_WebInput_.pressedKeys[quorumEvent.Get_Libraries_Interface_Events_KeyboardEvent__keyCode_()])
                 {

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
@@ -50,20 +50,26 @@ function plugins_quorum_Libraries_Game_WebInput_()
         public constant integer RELEASED_MOUSE = 4
         public constant integer SCROLLED_MOUSE = 5
         */
-        
-        plugins_quorum_Libraries_Game_WebInput_.MouseDown = function(event)
+
+        const isMouseInCanvas = function(event)
         {
             var canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
             var rect = canvas.getBoundingClientRect();
-
+            return event.clientX >= rect.left && event.clientX <= rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom;
+        };
+        
+        plugins_quorum_Libraries_Game_WebInput_.MouseDown = function(event)
+        {
             /*
              * Testing for mouse click using the dimensions of the rectangle
              * allows the first click on the window (i.e. the one that gives the
              * window focus) to trigger a mouse event, and prevents clicks from
              * outside the window being captured.
              */
-            if (event.clientX >= rect.left && event.clientX <= rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom)
+            if (isMouseInCanvas(event))
             {
+                event.stopPropagation();
+                event.preventDefault();
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 1);
                 plugins_quorum_Libraries_Game_WebInput_.mouseEvents.push(quorumEvent);
             }
@@ -71,6 +77,12 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.MouseUp = function(event)
         {
+            if (isMouseInCanvas(event))
+            {
+                event.stopPropagation();
+                event.preventDefault();
+            }
+
             if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 4);
@@ -80,6 +92,12 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.MouseMove = function(event)
         {
+            if (isMouseInCanvas(event))
+            {
+                event.stopPropagation();
+                event.preventDefault();
+            }
+
             if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 // If no mouse buttons pressed, send code for MOVED_MOUSE. Otherwise, send DRAGGED_MOUSE.
@@ -90,6 +108,12 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.MouseScroll = function(event)
         {
+            if (isMouseInCanvas(event))
+            {
+                event.stopPropagation();
+                event.preventDefault();
+            }
+
             if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 5);

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
@@ -126,7 +126,10 @@ function plugins_quorum_Libraries_Game_WebInput_()
             if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsCanvasFocused())
             {
                 if (plugins_quorum_Libraries_Game_WebInput_.disableContextMenu)
+                {
+                    event.stopPropagation();
                     event.preventDefault();
+                }
             }
         };
         
@@ -524,7 +527,10 @@ function plugins_quorum_Libraries_Game_WebInput_()
                 }
                 
                 if (event.code !== "Tab" || plugins_quorum_Libraries_Game_WebInput_.keepTabFocus())
+                {
+                    event.stopPropagation();
                     event.preventDefault();
+                }
             }
             else
             {
@@ -930,7 +936,10 @@ function plugins_quorum_Libraries_Game_WebInput_()
                 }
                 
                 if (event.keyCode !== 9 || plugins_quorum_Libraries_Game_WebInput_.keepTabFocus())
+                {
+                    event.stopPropagation();
                     event.preventDefault();
+                }
             }
             
             if (createTextEvent && pressed)

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -135,14 +135,8 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
             return;
         }
         currentFocus = item;
-        //TEXTBOX or TEXTFIELD
-        if (item.GetAccessibilityCode() == 6 || item.GetAccessibilityCode() == 17){
-            var element = document.getElementById(id);
-            element.focus;
-        }
-        
-        var element = document.getElementById(currentIDECanvas_$Global_);
-        element.setAttribute("aria-activedescendant", id);
+        var element = document.getElementById(id);
+        element.focus();
         
     };
 //    system action NativeAdd(Item item)
@@ -451,7 +445,18 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
         para.setAttribute("role",role);
         para.setAttribute("aria-label", itemName);
         para.setAttribute("aria-description", item.GetDescription())
-        para.tabindex = -1;
+
+        if (item.IsFocusable()) {
+            para.setAttribute("tabindex", "-1");
+            para.addEventListener("focus", (event) => {
+                if (event.target !== para) {
+                    return; // ignore bubbled events
+                }
+                if (currentFocus !== para) {
+                    item.Focus();
+                }
+            });
+        }
 
         //add element to a parent if need be or directly to canvas
         if (parent != undefined) {

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -458,6 +458,16 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
             });
         }
 
+        if (global_InstanceOf(item,"Libraries.Interface.Controls.Control")) {
+            let control = global_CheckCast(item, "Libraries.Interface.Controls.Control");
+            para.addEventListener("click", (event) => {
+                if (event.target !== para) {
+                    return; // ignore bubbled events
+                }
+                control.Activate();
+            });
+        }
+
         //add element to a parent if need be or directly to canvas
         if (parent != undefined) {
             var parentElement = document.getElementById(parent);


### PR DESCRIPTION
1. `WebAccessibility` now sets the actual DOM focus to shadow elements, rather than setting `aria-activedescendant` on the canvas.
2. The `tabindex` attribute is now actually set on shadow elements, but only for focusable Quorum items.
3. `WebInput` and `InputMonitor` now test whether the DOM focus is in the canvas or one of its descendants, rather than just the canvas.
4. `WebInput` now captures events, rather than letting them bubble up, to make sure it handles them before the browser default behavior runs, even when the focus is in a descendant of the canvas.
5. `WebInput` now suppresses propagation and default behavior for mouse events, only if the mouse is inside the canvas.
6. `WebAccessibility` now adds a focus event listener to focusable items, so it can set the Quorum focus when an AT programmatically focuses an element.
7. Likewise, `WebAccessibility` now adds a click event listener on control elements, so it can call `Activate` on the Quorum control when an AT programmatically "clicks" the element.
8. `keepTabFocus` in `WebConfiguration` now defaults to true. It seems to me that this is the better default in most cases; in particular, for programs run in the online IDE (e.g. on the Kitchen Sink) page, it's cleaner to trap tabbing on the Quorum side than to try to do so on the embedding side. Also, the behavior of relinquishing focus when the user presses Escape is now implemented in `WebInput` rather than in the JavaScript on the Quorum website; it's no longer possible for the latter to implement it, now that we're capturing key events.