### PR TITLE
New dialog-based focus trapping

### DIFF
--- a/Quorum/Library/Standard/Libraries/Game/Game.quorum
+++ b/Quorum/Library/Standard/Libraries/Game/Game.quorum
@@ -3000,9 +3000,11 @@ class Game
     end
 
     /*
-    This action sets the name of the game displayed at the top of the window. 
-    The default name is "Game". This action should be called before calling
-    StartGame(). This will have no effect on non-Desktop platforms.
+    This action sets the name of the game. The default name is "Game".
+    This action should be called before calling StartGame().
+    On desktop platforms, this name is displayed at the top of the window.
+    On the web, it is only used for accessibility. This action currently has
+    no effect on other platforms.
 
     Attribute: Parameter name The name to display on the Game window.
 
@@ -3020,6 +3022,7 @@ class Game
     */
     action SetGameName(text name)
         desktopConfig:title = name
+        webConfig:title = name
     end
 
     /*

--- a/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
+++ b/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
@@ -54,4 +54,7 @@ class WebConfiguration is ApplicationConfiguration
     */
     public number multipleKeyPressTimer = 0.5
 
+    /* The title of the application. */
+    public text title = "Game"
+
 end

--- a/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
+++ b/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
@@ -32,15 +32,6 @@ class WebConfiguration is ApplicationConfiguration
     public boolean disableContextMenu = true
 
     /*
-    The keepTabFocus flag controls how a game responds to the Tab key. Online
-    games must have the focus to receive input (the user has either clicked on
-    the game window or tabbed to it). If keepTabFocus is false and the user
-    presses the Tab key, the window will lose focus. If it is true, the window
-    will keep the focus even if the user presses Tab.
-    */
-    public boolean keepTabFocus = true
-
-    /*
     The maximum number of seconds allowed between each mouse click before the
     click is no longer considered related to the previous click. This is used
     for things such as double-click input.

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/InputMonitor.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/InputMonitor.js
@@ -2,7 +2,7 @@ function plugins_quorum_Libraries_Game_InputMonitor_()
 {
     this.IsKeyPressed$quorum_integer = function(keyCode)
     {
-        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
+        if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             return plugins_quorum_Libraries_Game_WebInput_.pressedKeys[keyCode] === true;
 
         return false;
@@ -10,7 +10,7 @@ function plugins_quorum_Libraries_Game_InputMonitor_()
     
     this.IsMouseButtonPressed$quorum_integer = function(buttonCode)
     {
-        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
+        if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
         {
             var buttons = plugins_quorum_Libraries_Game_WebInput_.mouseInfo.buttons;
             switch (buttonCode)
@@ -55,7 +55,7 @@ function plugins_quorum_Libraries_Game_InputMonitor_()
     
     this.IsClicked = function()
     {
-        if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
+        if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             return plugins_quorum_Libraries_Game_WebInput_.mouseInfo.buttons > 0;
     };
     

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebApplication.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebApplication.js
@@ -51,6 +51,12 @@ function plugins_quorum_Libraries_Game_WebApplication_()
             return;
         }
         
+        let accessibility = game.GetAccessibility();
+        if (accessibility)
+        {
+            accessibility.plugin_.Setup();
+        }
+        
         game.InitializeLayers();
         game.CreateGame();
         

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebDisplay.js
@@ -29,9 +29,6 @@ function plugins_quorum_Libraries_Game_WebDisplay_()
         }
         container = document.getElementById(id);
 
-        container.setAttribute("tabindex", "0");
-        container.setAttribute("role", "application");
-
         canvas = document.createElement("canvas");
         canvas.setAttribute("aria-hidden", "true");
         canvas.style.outline = "none";
@@ -51,18 +48,6 @@ function plugins_quorum_Libraries_Game_WebDisplay_()
     this.GetContainer = function()
     {
         return container;
-    };
-    
-    this.IsFocused = function()
-    {
-        let element = document.activeElement;
-        while (element) {
-            if (element === container) {
-                return true;
-            }
-            element = element.parentElement;
-        }
-        return false;
     };
     
     this.SetDisplayMode$quorum_integer$quorum_integer$quorum_boolean = function(width, height, fullscreen)

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
@@ -77,9 +77,9 @@ function plugins_quorum_Libraries_Game_WebInput_()
         {
             if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             {
-                if (event.code === "Escape" && plugins_quorum_Libraries_Game_WebInput_.keepTabFocus())
+                if (event.code === "Escape")
                 {
-                    // If we trap focus inside the canvas, give the user a way
+                    // Since we trap focus inside the canvas, give the user a way
                     // to get out. Do this in the key up handler to ensure
                     // Quorum gets the key up event for Escape, even though
                     // the canvas is about to lose focus.
@@ -581,11 +581,8 @@ function plugins_quorum_Libraries_Game_WebInput_()
                         quorumEvent.Set_Libraries_Interface_Events_KeyboardEvent__keyCode_(quorumEvent.Get_Libraries_Interface_Events_KeyboardEvent__UNKNOWN_());
                 }
                 
-                if (event.code !== "Tab" || plugins_quorum_Libraries_Game_WebInput_.keepTabFocus())
-                {
-                    event.stopPropagation();
-                    event.preventDefault();
-                }
+                event.stopPropagation();
+                event.preventDefault();
             }
             else
             {
@@ -990,11 +987,8 @@ function plugins_quorum_Libraries_Game_WebInput_()
                         quorumEvent.Set_Libraries_Interface_Events_KeyboardEvent__keyCode_(quorumEvent.Get_Libraries_Interface_Events_KeyboardEvent__UNKNOWN_());
                 }
                 
-                if (event.keyCode !== 9 || plugins_quorum_Libraries_Game_WebInput_.keepTabFocus())
-                {
-                    event.stopPropagation();
-                    event.preventDefault();
-                }
+                event.stopPropagation();
+                event.preventDefault();
             }
             
             if (createTextEvent && pressed)
@@ -1129,11 +1123,6 @@ function plugins_quorum_Libraries_Game_WebInput_()
             }
             
             return quorumEvent;
-        };
-    
-        plugins_quorum_Libraries_Game_WebInput_.keepTabFocus = function()
-        {
-            return plugins_quorum_Libraries_Game_GameStateManager_.application.plugin_.GetConfiguration().Get_Libraries_Game_WebConfiguration__keepTabFocus_();
         };
         
         plugins_quorum_Libraries_Game_WebInput_.disableContextMenu = function()

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
@@ -14,9 +14,54 @@ function plugins_quorum_Libraries_Game_WebInput_()
         plugins_quorum_Libraries_Game_WebInput_.mouseInfo.buttons = 0;
         plugins_quorum_Libraries_Game_WebInput_.mouseInfo.wheel = 0;
         
+        plugins_quorum_Libraries_Game_WebInput_.IsFocused = function()
+        {
+            let accessibilityRoot;
+            let game = plugins_quorum_Libraries_Game_GameStateManager_.game;
+            if (game) {
+                let accessibility = game.GetAccessibility();
+                if (accessibility) {
+                    accessibilityRoot = accessibility.plugin_.GetRoot();
+                }
+            }
+            let canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
+            let element = document.activeElement;
+            while (element) {
+                if ((element === accessibilityRoot) || (element === canvas)) {
+                    return true;
+                }
+                element = element.parentElement;
+            }
+            return false;
+        };
+        
+        plugins_quorum_Libraries_Game_WebInput_.TakeFocus = function()
+        {
+            if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
+            {
+                return;
+            }
+
+            let game = plugins_quorum_Libraries_Game_GameStateManager_.game;
+            let accessibility = game.GetAccessibility();
+            accessibility.plugin_.InternalTakeFocus();
+        };
+        
+        plugins_quorum_Libraries_Game_WebInput_.ReleaseFocus = function()
+        {
+            if (!plugins_quorum_Libraries_Game_WebInput_.IsFocused())
+            {
+                return;
+            }
+
+            let game = plugins_quorum_Libraries_Game_GameStateManager_.game;
+            let accessibility = game.GetAccessibility();
+            accessibility.plugin_.InternalReleaseFocus();
+        };
+        
         plugins_quorum_Libraries_Game_WebInput_.KeyDown = function(event)
         {
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
+            if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumKeyEvent(event, true);
                 if (!plugins_quorum_Libraries_Game_WebInput_.pressedKeys[quorumEvent.Get_Libraries_Interface_Events_KeyboardEvent__keyCode_()])
@@ -30,7 +75,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.KeyUp = function(event)
         {
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
+            if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             {
                 if (event.code === "Escape" && plugins_quorum_Libraries_Game_WebInput_.keepTabFocus())
                 {
@@ -38,7 +83,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
                     // to get out. Do this in the key up handler to ensure
                     // Quorum gets the key up event for Escape, even though
                     // the canvas is about to lose focus.
-                    document.activeElement.blur();
+                    plugins_quorum_Libraries_Game_WebInput_.ReleaseFocus();
                 }
 
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumKeyEvent(event, false);
@@ -79,6 +124,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
             {
                 event.stopPropagation();
                 event.preventDefault();
+                plugins_quorum_Libraries_Game_WebInput_.TakeFocus();
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 1);
                 plugins_quorum_Libraries_Game_WebInput_.mouseEvents.push(quorumEvent);
             }
@@ -92,7 +138,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
                 event.preventDefault();
             }
 
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
+            if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 4);
                 plugins_quorum_Libraries_Game_WebInput_.mouseEvents.push(quorumEvent);
@@ -107,7 +153,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
                 event.preventDefault();
             }
 
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
+            if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             {
                 // If no mouse buttons pressed, send code for MOVED_MOUSE. Otherwise, send DRAGGED_MOUSE.
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, event.buttons > 0 ? 3 : 2);
@@ -123,7 +169,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
                 event.preventDefault();
             }
 
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
+            if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             {
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 5);
                 plugins_quorum_Libraries_Game_WebInput_.mouseEvents.push(quorumEvent);
@@ -132,7 +178,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         
         plugins_quorum_Libraries_Game_WebInput_.ContextMenu = function(event)
         {
-            if (plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.IsFocused())
+            if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             {
                 if (plugins_quorum_Libraries_Game_WebInput_.disableContextMenu)
                 {

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
@@ -24,10 +24,9 @@ function plugins_quorum_Libraries_Game_WebInput_()
                     accessibilityRoot = accessibility.plugin_.GetRoot();
                 }
             }
-            let canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
             let element = document.activeElement;
             while (element) {
-                if ((element === accessibilityRoot) || (element === canvas)) {
+                if (element === accessibilityRoot) {
                     return true;
                 }
                 element = element.parentElement;

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -30,9 +30,10 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
 
     this.Setup = function() {
         let container = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetContainer();
+        let title = plugins_quorum_Libraries_Game_GameStateManager_.application.plugin_.GetConfiguration().Get_Libraries_Game_WebConfiguration__title_();
 
         root = document.createElement("div");
-        root.setAttribute("aria-label", "Application");
+        root.setAttribute("aria-label", title);
         root.setAttribute("tabindex", "-1");
         root.setAttribute("role", "dialog");
         root.hidden = true;
@@ -62,7 +63,7 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
         container.appendChild(root);
 
         entryButton = document.createElement("button");
-        entryButton.setAttribute("aria-label", "Enter Application");
+        entryButton.setAttribute("aria-label", title);
 
         entryButton.style.position = "absolute";
         entryButton.style.left = 0;

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -16,7 +16,7 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
             // Delay processing of this event until the next event cycle,
             // in case focus is being moved to another accessibility element.
             if (blurDelayedCall === null) {
-              blurDelayedCall = setTimeout(() => {
+                blurDelayedCall = setTimeout(() => {
                     if (plugins_quorum_Libraries_Game_WebInput_.IsFocused()) {
                         return;
                     }


### PR DESCRIPTION
Quorum's flexible implementation of tab order requires that we trap focus inside the Quorum application on the web platform, so Quorum can handle tabbing rather than the browser. To do this in a way that makes sense to screen reader users, we now expose the root of the shadow DOM tree as a dialog, which the user can exit by pressing Escape, and provide a button to move focus into the dialog.