### PR TITLE
Correctly distinguish between real and fake mouse events

### DIFF
--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Game/WebInput.js
@@ -107,8 +107,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
         plugins_quorum_Libraries_Game_WebInput_.IsMouseInCanvas = function(event)
         {
             var canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
-            var rect = canvas.getBoundingClientRect();
-            return event.clientX >= rect.left && event.clientX <= rect.right && event.clientY >= rect.top && event.clientY <= rect.bottom;
+            return event.target === canvas;
         };
         
         plugins_quorum_Libraries_Game_WebInput_.MouseDown = function(event)
@@ -121,6 +120,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
              */
             if (plugins_quorum_Libraries_Game_WebInput_.IsMouseInCanvas(event))
             {
+                console.log(`mousedown ${event.clientX} ${event.clientY} ${event.target.tagName} ${event.target.id}`);
                 event.stopPropagation();
                 event.preventDefault();
                 plugins_quorum_Libraries_Game_WebInput_.TakeFocus();
@@ -139,6 +139,7 @@ function plugins_quorum_Libraries_Game_WebInput_()
 
             if (plugins_quorum_Libraries_Game_WebInput_.IsFocused())
             {
+                console.log(`mouseup ${event.clientX} ${event.clientY} ${event.target.tagName} ${event.target.id}`);
                 var quorumEvent = plugins_quorum_Libraries_Game_WebInput_.ConvertToQuorumMouseEvent(event, 4);
                 plugins_quorum_Libraries_Game_WebInput_.mouseEvents.push(quorumEvent);
             }

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -30,6 +30,7 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
 
     this.Setup = function() {
         let container = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetContainer();
+        let canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
         let title = plugins_quorum_Libraries_Game_GameStateManager_.application.plugin_.GetConfiguration().Get_Libraries_Game_WebConfiguration__title_();
 
         root = document.createElement("div");
@@ -60,7 +61,10 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
 
         addBlurListener(root);
 
-        container.appendChild(root);
+        // Accessibility elements must be inserted before the canvas, to ensure
+        // that real mouse events get routed to the canvas while simulated
+        // mouse events get routed to the accessibility elements.
+        container.insertBefore(root, canvas);
 
         entryButton = document.createElement("button");
         entryButton.setAttribute("aria-label", title);
@@ -76,15 +80,12 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
         entryButton.style.color = "rgba(0,0,0,0)";
 
         entryButton.addEventListener("click", (event) => {
-            // If this is an actual pointer event and not a programmatic
-            // activation by an AT, ignore it.
-            if (plugins_quorum_Libraries_Game_WebInput_.IsMouseInCanvas(event)) {
-                return;
-            }
             plugins_quorum_Libraries_Game_WebInput_.TakeFocus();
         });
 
-        container.appendChild(entryButton);
+        // Like the accessibility root, this element must be inserted before
+        // the canvas.
+        container.insertBefore(entryButton, canvas);
     };
 
     this.GetRoot = function() {
@@ -624,11 +625,6 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
             para.addEventListener("click", (event) => {
                 if (event.target !== para) {
                     return; // ignore bubbled events
-                }
-                // If this is an actual pointer event and not a programmatic
-                // activation by an AT, ignore it.
-                if (plugins_quorum_Libraries_Game_WebInput_.IsMouseInCanvas(event)) {
-                    return;
                 }
                 control.Activate();
             });


### PR DESCRIPTION
Previously, the fake mouse events generated by browsers in response to accessibility API calls were being handled by `WebInput` rather than `WebAccessibility`. This more or less worked, but it meant that when a screen reader user pressed the button to enter the application, Quorum would treat this as a click at an unpredictable point within the canvas, leading to erratic behavior such as focusing a random control. Now, by inserting the accessibility elements before the canvas within the top-level container, we can reliably distinguish between the two kinds of mouse events.