### PR TITLE
Focus trapping: Set aria-modal; more work on dialog and button names

### DIFF
--- a/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
+++ b/Quorum/Library/Standard/Libraries/Game/WebConfiguration.quorum
@@ -45,7 +45,14 @@ class WebConfiguration is ApplicationConfiguration
     */
     public number multipleKeyPressTimer = 0.5
 
-    /* The title of the application. */
-    public text title = "Game"
+    /* The title of the application. If undefined, defaults to "Game". */
+    public text title = undefined
+
+    /*
+    The name of the button that assistive technology users will press
+    to move focus into the application. If undefined, defaults to
+    "Enter " followed by the title.
+    */
+    public text focusButtonName = undefined
 
 end

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -8,7 +8,7 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
     var elementList = [];   // array using the item's hashCode value as an index and the item as the value 
     var currentFocus = null;
     let root = null;
-    let entryButton = null;
+    let focusButton = null;
     let blurDelayedCall = null;
 
     const addBlurListener = function(element) {
@@ -21,7 +21,7 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
                         return;
                     }
                     blurDelayedCall = null;
-                    entryButton.hidden = false;
+                    focusButton.hidden = false;
                     root.hidden = true;
                 });
             }
@@ -31,7 +31,24 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
     this.Setup = function() {
         let container = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetContainer();
         let canvas = plugins_quorum_Libraries_Game_GameStateManager_.display.plugin_.GetCanvas();
-        let title = plugins_quorum_Libraries_Game_GameStateManager_.application.plugin_.GetConfiguration().Get_Libraries_Game_WebConfiguration__title_();
+        let config = plugins_quorum_Libraries_Game_GameStateManager_.application.plugin_.GetConfiguration();
+
+        let title = config.Get_Libraries_Game_WebConfiguration__title_();
+        if (title == null) {
+            title = container.dataset.title;
+            if (title == null) {
+                title = "Game";
+            }
+        }
+
+        let focusButtonName = config.Get_Libraries_Game_WebConfiguration__focusButtonName_();
+        if (focusButtonName == null) {
+            focusButtonName = container.dataset.focusButtonName;
+            if (focusButtonName == null) {
+                // Revisit this if Quorum gets localization support.
+                focusButtonName = `Enter ${title}`;
+            }
+        }
 
         root = document.createElement("div");
         root.setAttribute("aria-label", title);
@@ -67,26 +84,26 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
         // mouse events get routed to the accessibility elements.
         container.insertBefore(root, canvas);
 
-        entryButton = document.createElement("button");
-        entryButton.setAttribute("aria-label", title);
+        focusButton = document.createElement("button");
+        focusButton.setAttribute("aria-label", focusButtonName);
 
-        entryButton.style.position = "absolute";
-        entryButton.style.left = 0;
-        entryButton.style.bottom = 0;
-        entryButton.style.width = "100%";
-        entryButton.style.height = "100%";
+        focusButton.style.position = "absolute";
+        focusButton.style.left = 0;
+        focusButton.style.bottom = 0;
+        focusButton.style.width = "100%";
+        focusButton.style.height = "100%";
 
         // The rationales for the following styles are the same as for the root.
-        entryButton.style.filter = "opacity(0%)";
-        entryButton.style.color = "rgba(0,0,0,0)";
+        focusButton.style.filter = "opacity(0%)";
+        focusButton.style.color = "rgba(0,0,0,0)";
 
-        entryButton.addEventListener("click", (event) => {
+        focusButton.addEventListener("click", (event) => {
             plugins_quorum_Libraries_Game_WebInput_.TakeFocus();
         });
 
         // Like the accessibility root, this element must be inserted before
         // the canvas.
-        container.insertBefore(entryButton, canvas);
+        container.insertBefore(focusButton, canvas);
     };
 
     this.GetRoot = function() {
@@ -103,12 +120,12 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
         }
         root.hidden = false;
         element.focus();
-        entryButton.hidden = true;
+        focusButton.hidden = true;
     };
 
     this.InternalReleaseFocus = function() {
-        entryButton.hidden = false;
-        entryButton.focus();
+        focusButton.hidden = false;
+        focusButton.focus();
         root.hidden = true;
     };
 

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -37,6 +37,7 @@ function plugins_quorum_Libraries_Interface_Accessibility_WebAccessibility_() {
         root.setAttribute("aria-label", title);
         root.setAttribute("tabindex", "-1");
         root.setAttribute("role", "dialog");
+        root.setAttribute("aria-modal", true);
         root.hidden = true;
 
         root.style.position = "absolute";


### PR DESCRIPTION
The aria-modal attribute is now set on the dialog.

The names of the dialog and button can now be customized independently, both in `WebConfiguration` and through data attributes on the container element.