### PR TITLE
Fix incorrect use of ARIA region role

### DIFF
--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -335,7 +335,7 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
         elementList[id] = item;      //adds the item to the elementList array using the item's HashCode value as an index
         elementType = "DIV";
         //default role
-        let role = "region";
+        let role = null;
 
         /* Creating Item Element Tag with Attributes */
         var parent = undefined; // used if item needs to be added to group
@@ -346,6 +346,7 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
             //ITEM or CUSTOM
             case 0:
             case 1:
+                role = "img";
                 para.setAttribute("aria-roledescription","");
                 break;
             //CHECKBOX
@@ -620,7 +621,9 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
             }
         }
 
-        para.setAttribute("role",role);
+        if (role != null) {
+            para.setAttribute("role",role);
+        }
         para.setAttribute("aria-label", itemName);
         para.setAttribute("aria-description", item.GetDescription())
 


### PR DESCRIPTION
1. The region ARIA role isn't appropriate for custom items. The best role we have for this is "img".
2. There's no longer a default ARIA role for all elements where one isn't set. In particular, this means that a role is no longer set for text fields, where we use an actual HTML input element.