### PR TITLE
More work on support for custom items

### DIFF
--- a/Plugins/AccessibilityPlugin/Native/Windows/src/Item.cpp
+++ b/Plugins/AccessibilityPlugin/Native/Windows/src/Item.cpp
@@ -93,6 +93,25 @@ const WCHAR* Item::GetName()
 	return m_ControlName.c_str();
 }
 
+std::wstring Item::GetRoleDescription()
+{
+	auto env = GetJNIEnv();
+	if (env)
+	{
+		jstring jDescription = reinterpret_cast<jstring>(env->CallObjectMethod(javaItem, JavaClass_Item.GetAccessibilityRoleDescription));
+
+		if (jDescription)
+		{
+			auto nativeDescription = env->GetStringUTFChars(jDescription, 0);
+			auto wDescription = CreateWideStringFromUTF8Win32(nativeDescription);
+			env->ReleaseStringUTFChars(jDescription, nativeDescription);
+			return wDescription;
+		}
+	}
+
+	return L"";
+}
+
 void Item::SetDescription(_In_ std::wstring description)
 {
 	VARIANT oldDescription, newDescription;

--- a/Plugins/AccessibilityPlugin/Native/Windows/src/Item.h
+++ b/Plugins/AccessibilityPlugin/Native/Windows/src/Item.h
@@ -35,6 +35,7 @@ public:
 	const WCHAR* GetName();
 	void SetDescription(_In_ std::wstring description);
 	const WCHAR* GetDescription();
+    std::wstring GetRoleDescription();
 	jobject GetMe();
 	int GetUniqueId() const noexcept;
 

--- a/Plugins/AccessibilityPlugin/Native/Windows/src/ProviderT.h
+++ b/Plugins/AccessibilityPlugin/Native/Windows/src/ProviderT.h
@@ -75,6 +75,13 @@ public:
 				retVal->vt = VT_I4;
 				break;
 
+			case UIA_LocalizedControlTypePropertyId:
+			{
+				auto roleDescription = m_control->GetRoleDescription();
+				SetBstrPropertyValueIfNotEmpty(retVal, roleDescription.c_str());
+				break;
+			}
+
 			case UIA_HasKeyboardFocusPropertyId:
 				retVal->boolVal = m_control->HasUiaFocus() ? VARIANT_TRUE : VARIANT_FALSE;
 				retVal->vt = VT_BOOL;

--- a/Plugins/AccessibilityPlugin/Native/Windows/src/Resources.cpp
+++ b/Plugins/AccessibilityPlugin/Native/Windows/src/Resources.cpp
@@ -376,6 +376,7 @@ JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved)
 	//env->GetMethodID(JavaClass_TextBox.me, "GetText", "()Ljava/lang/String;");
 	JavaClass_Item.GetName = env->GetMethodID(JavaClass_Item.me, "GetName", "()Ljava/lang/String;");
 	JavaClass_Item.GetDescription = env->GetMethodID(JavaClass_Item.me, "GetDescription", "()Ljava/lang/String;");
+	JavaClass_Item.GetAccessibilityRoleDescription = env->GetMethodID(JavaClass_Item.me, "GetAccessibilityRoleDescription", "()Ljava/lang/String;");
 	// Delete local reference
 	env->DeleteLocalRef(tempLocalClassRef);
 	#pragma endregion

--- a/Plugins/AccessibilityPlugin/Native/Windows/src/Resources.h
+++ b/Plugins/AccessibilityPlugin/Native/Windows/src/Resources.h
@@ -152,6 +152,7 @@ struct JClass_Item
 	jclass me;
 	jmethodID GetName;
 	jmethodID GetDescription;
+    jmethodID GetAccessibilityRoleDescription;
 };
 struct JClass_ProgressBar
 {

--- a/Quorum/Library/Standard/Libraries/Interface/Item.quorum
+++ b/Quorum/Library/Standard/Libraries/Interface/Item.quorum
@@ -63,6 +63,7 @@ class Item
     public constant integer GROUP = 25
 
     private integer accessibilityCode = NOT_ACCESSIBLE
+    private text accessibilityRoleDescription = undefined
 
     text name = "Unnamed"
     text description = ""
@@ -1098,6 +1099,35 @@ class Item
     */
     action SetAccessibilityCode(integer newAccessibilityCode)
         accessibilityCode = newAccessibilityCode
+    end
+
+    /*
+        This action returns the custom accessibility role description
+        for this item, if any.
+    */
+    action GetAccessibilityRoleDescription() returns text
+        return accessibilityRoleDescription
+    end
+
+    /*
+        This action sets a custom accessibility role description for this item.
+        This should only be done if there is not a standard accessibility code
+        for the type of item being implemented. If the item behaves very
+        similarly to a standard control type, then set the accessibility
+        code to that standard type while also setting the role description.
+        For example, if implementing an item that extends Control,
+        is keyboard focusable, and responds to activation via both mouse
+        clicks and the Space key, like a button, but it shouldn't be
+        described as a button, then set the accessibility code to BUTTON
+        and the custom role description to whatever is appropriate.
+        If there isn't a suitable accessibility code, or if in doubt,
+        set the accessibility code to CUSTOM.
+        
+        Attribute: Parameter newRoleDescription the new custom role description for this Item.
+                                                  
+    */
+    action SetAccessibilityRoleDescription(text newRoleDescription)
+        accessibilityRoleDescription = newRoleDescription
     end
 
     /*

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -346,7 +346,11 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
             //ITEM or CUSTOM
             case 0:
             case 1:
-                role = "img";
+                if (item.IsFocusable()) {
+                    role = "application";
+                } else {
+                    role = "img";
+                }
                 para.setAttribute("aria-roledescription","");
                 break;
             //CHECKBOX

--- a/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
+++ b/Quorum/Library/Standard/Plugins/javascript/Libraries/Interface/Accessibility/WebAccessibility.js
@@ -336,6 +336,7 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
         elementType = "DIV";
         //default role
         let role = null;
+        let roleDescription = item.GetAccessibilityRoleDescription();
 
         /* Creating Item Element Tag with Attributes */
         var parent = undefined; // used if item needs to be added to group
@@ -351,7 +352,14 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
                 } else {
                     role = "img";
                 }
-                para.setAttribute("aria-roledescription","");
+                // If a custom role description isn't provided, an empty string
+                // will indicate that while assistive technologies should treat
+                // this item like an application, e.g. by switching into
+                // focus mode, it's not really an application, but we don't know
+                // what it is.
+                if (roleDescription == null) {
+                    roleDescription = "";
+                }
                 break;
             //CHECKBOX
             case 2:
@@ -627,6 +635,9 @@ this.ToggleButtonToggled$quorum_Libraries_Interface_Controls_ToggleButton = func
 
         if (role != null) {
             para.setAttribute("role",role);
+        }
+        if (roleDescription != null) {
+            para.setAttribute("aria-roledescription", roleDescription);
         }
         if (itemName != null) {
             para.setAttribute("aria-label", itemName);


### PR DESCRIPTION
1. The shadow DOM implementation now uses the application role for focusable custom items, e.g. charts.
2. Quorum can now expose custom role descriptions through both the shadow DOM and UIA.